### PR TITLE
Add TransformPlayground with anchor support for scaleEffect and rotationEffect

### DIFF
--- a/Sources/ShowcaseFuse/PlaygroundListView.swift
+++ b/Sources/ShowcaseFuse/PlaygroundListView.swift
@@ -79,6 +79,7 @@ enum PlaygroundType: CaseIterable, View {
     case toggle
     case toolbar
     case tracking
+    case transform
     case timer
     case transition
     case videoPlayer
@@ -244,6 +245,8 @@ enum PlaygroundType: CaseIterable, View {
             return LocalizedStringResource("Toolbar", comment: "Title of Toolbar playground")
         case .tracking:
             return LocalizedStringResource("Tracking", comment: "Title of Tracking playground")
+        case .transform:
+            return LocalizedStringResource("Transform", comment: "Title of Transform playground")
         case .transition:
             return LocalizedStringResource("Transition", comment: "Title of Transition playground")
         case .videoPlayer:
@@ -417,6 +420,8 @@ enum PlaygroundType: CaseIterable, View {
             ToolbarPlayground()
         case .tracking:
             TrackingPlayground()
+        case .transform:
+            TransformPlayground()
         case .transition:
             TransitionPlayground()
         case .videoPlayer:

--- a/Sources/ShowcaseFuse/Resources/Localizable.xcstrings
+++ b/Sources/ShowcaseFuse/Resources/Localizable.xcstrings
@@ -91,10 +91,16 @@
     ".borderedProminent: %lld" : {
 
     },
+    ".bottomTrailing" : {
+
+    },
     ".buttonStyle(.bordered)" : {
 
     },
     ".buttonStyle(.plain)" : {
+
+    },
+    ".center" : {
 
     },
     ".clipped()" : {
@@ -690,6 +696,9 @@
     "Also see the `Transition` playground for view enter/exit animations" : {
 
     },
+    "Anchor" : {
+
+    },
     "Android: Disabled by default for performance" : {
 
     },
@@ -1140,6 +1149,9 @@
 
     },
     "Default URL" : {
+
+    },
+    "Demo" : {
 
     },
     "Destructive" : {
@@ -2426,6 +2438,9 @@
     "Requires iOS 17+" : {
 
     },
+    "Reset" : {
+
+    },
     "RGB" : {
 
     },
@@ -2435,7 +2450,13 @@
     "Rotation" : {
 
     },
+    "rotation + scale (.%@)" : {
+
+    },
     "rotation(Angle(degrees: 45))" : {
+
+    },
+    "rotationEffect(.%@)" : {
 
     },
     "RoundedRect mask" : {
@@ -2483,6 +2504,9 @@
     "SafeArea" : {
       "comment" : "Title of SafeArea playground"
     },
+    "Same angle, different anchors" : {
+
+    },
     "Save" : {
 
     },
@@ -2499,6 +2523,9 @@
 
     },
     "scaledToFill" : {
+
+    },
+    "scaleEffect(.%@)" : {
 
     },
     "ScenePhase" : {
@@ -3282,6 +3309,9 @@
     },
     "Trailing: %lld" : {
 
+    },
+    "Transform" : {
+      "comment" : "Title of Transform playground"
     },
     "Transforms" : {
 

--- a/Sources/ShowcaseFuse/TransformPlayground.swift
+++ b/Sources/ShowcaseFuse/TransformPlayground.swift
@@ -1,0 +1,213 @@
+// Copyright 2023–2025 Skip
+import SwiftUI
+
+struct TransformPlayground: View {
+    enum Tab: String, CaseIterable {
+        case rotation = "Rotation"
+        case scale = "Scale"
+        case combined = "Combined"
+    }
+
+    @State internal var selectedTab: Tab = .rotation
+    @State internal var rotationAngle: Double = 0
+    @State internal var scale: Double = 1.0
+    @State internal var selectedAnchor: AnchorChoice = .center
+
+    enum AnchorChoice: String, CaseIterable {
+        case topLeading, top, topTrailing
+        case leading, center, trailing
+        case bottomLeading, bottom, bottomTrailing
+
+        var unitPoint: UnitPoint {
+            switch self {
+            case .topLeading: return .topLeading
+            case .top: return .top
+            case .topTrailing: return .topTrailing
+            case .leading: return .leading
+            case .center: return .center
+            case .trailing: return .trailing
+            case .bottomLeading: return .bottomLeading
+            case .bottom: return .bottom
+            case .bottomTrailing: return .bottomTrailing
+            }
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("Demo", selection: $selectedTab) {
+                ForEach(Tab.allCases, id: \.self) { tab in
+                    Text(tab.rawValue).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .padding()
+
+            Divider()
+
+            switch selectedTab {
+            case .rotation:
+                rotationTab
+            case .scale:
+                scaleTab
+            case .combined:
+                combinedTab
+            }
+        }
+        .toolbar {
+            PlaygroundSourceLink(file: "TransformPlayground.swift")
+        }
+    }
+
+    // MARK: - Rotation Tab
+
+    private var rotationTab: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            transformPreview(color: .blue) {
+                $0.rotationEffect(.degrees(rotationAngle), anchor: selectedAnchor.unitPoint)
+            }
+
+            Text("rotationEffect(.\(selectedAnchor.rawValue))")
+                .font(.headline)
+                .monospaced()
+
+            Spacer()
+
+            controlsSection {
+                sliderRow(label: "Angle", value: $rotationAngle, range: -180...180, format: "%.0f°")
+            }
+        }
+    }
+
+    // MARK: - Scale Tab
+
+    private var scaleTab: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            transformPreview(color: .green) {
+                $0.scaleEffect(scale, anchor: selectedAnchor.unitPoint)
+            }
+
+            Text("scaleEffect(.\(selectedAnchor.rawValue))")
+                .font(.headline)
+                .monospaced()
+
+            Spacer()
+
+            controlsSection {
+                sliderRow(label: "Scale", value: $scale, range: 0.25...2.0, format: "%.2fx")
+            }
+        }
+    }
+
+    // MARK: - Combined Tab
+
+    private var combinedTab: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            transformPreview(color: .purple) {
+                $0.rotationEffect(.degrees(rotationAngle), anchor: selectedAnchor.unitPoint)
+                    .scaleEffect(scale, anchor: selectedAnchor.unitPoint)
+            }
+
+            Text("rotation + scale (.\(selectedAnchor.rawValue))")
+                .font(.headline)
+                .monospaced()
+
+            Spacer()
+
+            controlsSection {
+                sliderRow(label: "Angle", value: $rotationAngle, range: -180...180, format: "%.0f°")
+                sliderRow(label: "Scale", value: $scale, range: 0.25...2.0, format: "%.2fx")
+            }
+        }
+    }
+
+    // MARK: - Reusable Components
+
+    private func transformPreview<V: View>(color: Color, @ViewBuilder transform: @escaping (AnyView) -> V) -> some View {
+        ZStack {
+            anchorDot
+
+            transform(AnyView(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(color.opacity(0.8))
+                    .frame(width: 100, height: 100)
+            ))
+        }
+        .frame(width: 220, height: 220)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.gray.opacity(0.15))
+        )
+        .clipped()
+    }
+
+    private var anchorDot: some View {
+        Circle()
+            .fill(Color.red)
+            .frame(width: 10, height: 10)
+            .shadow(color: .red.opacity(0.5), radius: 4)
+            .position(anchorPosition(in: CGSize(width: 100, height: 100)))
+    }
+
+    private func controlsSection<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        VStack(spacing: 12) {
+            anchorPicker
+            content()
+            resetButton
+        }
+        .padding()
+        .background(Color.gray.opacity(0.1))
+    }
+
+    private var anchorPicker: some View {
+        HStack {
+            Text("Anchor")
+                .frame(width: 60, alignment: .leading)
+            Picker("Anchor", selection: $selectedAnchor) {
+                ForEach(AnchorChoice.allCases, id: \.self) { anchor in
+                    Text(anchor.rawValue).tag(anchor)
+                }
+            }
+            .pickerStyle(.menu)
+            Spacer()
+        }
+    }
+
+    private func sliderRow(label: String, value: Binding<Double>, range: ClosedRange<Double>, format: String) -> some View {
+        HStack {
+            Text(label)
+                .frame(width: 60, alignment: .leading)
+            Slider(value: value, in: range)
+            Text(String(format: format, value.wrappedValue))
+                .frame(width: 50, alignment: .trailing)
+                .monospaced()
+        }
+    }
+
+    private var resetButton: some View {
+        Button("Reset") {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                rotationAngle = 0
+                scale = 1.0
+                selectedAnchor = .center
+            }
+        }
+        .buttonStyle(.bordered)
+    }
+
+    private func anchorPosition(in size: CGSize) -> CGPoint {
+        let anchor = selectedAnchor.unitPoint
+        let centerX: CGFloat = 110
+        let centerY: CGFloat = 110
+        return CGPoint(
+            x: centerX + (anchor.x - 0.5) * size.width,
+            y: centerY + (anchor.y - 0.5) * size.height
+        )
+    }
+}


### PR DESCRIPTION
anchor support for scaleEffect and rotationEffect

this can probably be merged into the playground containing scaleEffect and rotationEffect evenutally, but I thought this is pretty interesting on how to get creative using these so I just added another playground for now 

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

