### PR TITLE
Add BlendMode playground

### DIFF
--- a/Sources/ShowcaseFuse/BackgroundPlayground.swift
+++ b/Sources/ShowcaseFuse/BackgroundPlayground.swift
@@ -132,6 +132,45 @@ struct BackgroundPlayground: View {
                         }
                         .border(.blue)
                 }
+
+                // Material backgrounds
+                Divider()
+                Text("Material Backgrounds").font(.headline)
+                Text("Simplified on Android: semi-transparent white overlay")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                ZStack {
+                    LinearGradient(colors: [.red, .blue, .green], startPoint: .topLeading, endPoint: .bottomTrailing)
+                    VStack(spacing: 8) {
+                        Text(".ultraThinMaterial")
+                            .padding()
+                            .background(.ultraThinMaterial)
+                        Text(".thinMaterial")
+                            .padding()
+                            .background(.thinMaterial)
+                        Text(".regularMaterial")
+                            .padding()
+                            .background(.regularMaterial)
+                        Text(".thickMaterial")
+                            .padding()
+                            .background(.thickMaterial)
+                        Text(".ultraThickMaterial")
+                            .padding()
+                            .background(.ultraThickMaterial)
+                    }
+                    .padding()
+                }
+                .frame(height: 300)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+
+                HStack {
+                    Text("Material in shape")
+                    Spacer()
+                    Text("Hello")
+                        .padding()
+                        .background(.regularMaterial, in: Capsule())
+                }
             }
             .padding()
         }

--- a/Sources/ShowcaseFuse/BlendModePlayground.swift
+++ b/Sources/ShowcaseFuse/BlendModePlayground.swift
@@ -130,52 +130,6 @@ struct BlendModePlayground: View {
 
                 Divider()
 
-                // compositingGroup demo
-                Section {
-                    Text("compositingGroup()")
-                        .font(.headline)
-
-                    Text("Isolates blend modes to the group")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                    HStack(spacing: 20) {
-                        VStack {
-                            Text("Without")
-                                .font(.caption)
-                            ZStack {
-                                Circle()
-                                    .fill(Color.green)
-                                    .frame(width: 60, height: 60)
-                                Circle()
-                                    .fill(Color.yellow)
-                                    .frame(width: 60, height: 60)
-                                    .offset(x: 20)
-                                    .blendMode(.multiply)
-                            }
-                        }
-
-                        VStack {
-                            Text("With compositingGroup")
-                                .font(.caption)
-                            ZStack {
-                                Circle()
-                                    .fill(Color.green)
-                                    .frame(width: 60, height: 60)
-                                Circle()
-                                    .fill(Color.yellow)
-                                    .frame(width: 60, height: 60)
-                                    .offset(x: 20)
-                                    .blendMode(.multiply)
-                            }
-                            .compositingGroup()
-                        }
-                    }
-                    .drawingGroup()
-                }
-
-                Divider()
-
                 // flipsForRightToLeftLayoutDirection demo
                 Section {
                     Text("flipsForRightToLeftLayoutDirection()")
@@ -254,27 +208,31 @@ struct FlipsForRTLDemo: View {
         VStack(spacing: 16) {
             Toggle("RTL Layout", isOn: $isRTL)
 
-            HStack(spacing: 20) {
+            HStack(spacing: 40) {
                 VStack {
                     Text("Normal")
                         .font(.caption)
-                    Image(systemName: "arrow.right")
-                        .font(.largeTitle)
+                    Text("→")
+                        .font(.system(size: 48))
                 }
 
                 VStack {
                     Text("Flips for RTL")
                         .font(.caption)
-                    Image(systemName: "arrow.right")
-                        .font(.largeTitle)
+                    Text("→")
+                        .font(.system(size: 48))
                         .flipsForRightToLeftLayoutDirection(true)
                 }
             }
             .environment(\.layoutDirection, isRTL ? .rightToLeft : .leftToRight)
 
-            Text(isRTL ? "Arrow should flip in RTL" : "Arrow points right in LTR")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+            HStack {
+                Text("Leading")
+                Spacer()
+                Text("Trailing")
+            }
+            .padding(.horizontal)
+            .environment(\.layoutDirection, isRTL ? .rightToLeft : .leftToRight)
         }
     }
 }

--- a/Sources/ShowcaseFuse/BlendModePlayground.swift
+++ b/Sources/ShowcaseFuse/BlendModePlayground.swift
@@ -127,6 +127,62 @@ struct BlendModePlayground: View {
 
                     AllowsHitTestingDemo()
                 }
+
+                Divider()
+
+                // compositingGroup demo
+                Section {
+                    Text("compositingGroup()")
+                        .font(.headline)
+
+                    Text("Isolates blend modes to the group")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    HStack(spacing: 20) {
+                        VStack {
+                            Text("Without")
+                                .font(.caption)
+                            ZStack {
+                                Circle()
+                                    .fill(Color.green)
+                                    .frame(width: 60, height: 60)
+                                Circle()
+                                    .fill(Color.yellow)
+                                    .frame(width: 60, height: 60)
+                                    .offset(x: 20)
+                                    .blendMode(.multiply)
+                            }
+                        }
+
+                        VStack {
+                            Text("With compositingGroup")
+                                .font(.caption)
+                            ZStack {
+                                Circle()
+                                    .fill(Color.green)
+                                    .frame(width: 60, height: 60)
+                                Circle()
+                                    .fill(Color.yellow)
+                                    .frame(width: 60, height: 60)
+                                    .offset(x: 20)
+                                    .blendMode(.multiply)
+                            }
+                            .compositingGroup()
+                        }
+                    }
+                    .drawingGroup()
+                }
+
+                Divider()
+
+                // flipsForRightToLeftLayoutDirection demo
+                Section {
+                    Text("flipsForRightToLeftLayoutDirection()")
+                        .font(.headline)
+
+                    FlipsForRTLDemo()
+                }
             }
             .padding()
         }
@@ -185,6 +241,38 @@ struct AllowsHitTestingDemo: View {
             }
 
             Text(hitTestingEnabled ? "Red overlay blocks taps" : "Taps pass through overlay")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+struct FlipsForRTLDemo: View {
+    @State internal var isRTL = false
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Toggle("RTL Layout", isOn: $isRTL)
+
+            HStack(spacing: 20) {
+                VStack {
+                    Text("Normal")
+                        .font(.caption)
+                    Image(systemName: "arrow.right")
+                        .font(.largeTitle)
+                }
+
+                VStack {
+                    Text("Flips for RTL")
+                        .font(.caption)
+                    Image(systemName: "arrow.right")
+                        .font(.largeTitle)
+                        .flipsForRightToLeftLayoutDirection(true)
+                }
+            }
+            .environment(\.layoutDirection, isRTL ? .rightToLeft : .leftToRight)
+
+            Text(isRTL ? "Arrow should flip in RTL" : "Arrow points right in LTR")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/Sources/ShowcaseFuse/BlendModePlayground.swift
+++ b/Sources/ShowcaseFuse/BlendModePlayground.swift
@@ -1,0 +1,192 @@
+// Copyright 2023–2025 Skip
+import SwiftUI
+
+struct BlendModePlayground: View {
+    @State internal var selectedMode: BlendMode = .multiply
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                // Interactive blend mode picker
+                Section {
+                    VStack(spacing: 16) {
+                        Text("Select Blend Mode")
+                            .font(.headline)
+
+                        Picker("Blend Mode", selection: $selectedMode) {
+                            Text("Normal").tag(BlendMode.normal)
+                            Text("Multiply").tag(BlendMode.multiply)
+                            Text("Screen").tag(BlendMode.screen)
+                            Text("Overlay").tag(BlendMode.overlay)
+                            Text("Darken").tag(BlendMode.darken)
+                            Text("Lighten").tag(BlendMode.lighten)
+                            Text("Color Dodge").tag(BlendMode.colorDodge)
+                            Text("Color Burn").tag(BlendMode.colorBurn)
+                            Text("Difference").tag(BlendMode.difference)
+                            Text("Exclusion").tag(BlendMode.exclusion)
+                        }
+                        .pickerStyle(.menu)
+
+                        ZStack {
+                            Circle()
+                                .fill(Color.blue)
+                                .frame(width: 120, height: 120)
+                                .offset(x: -30)
+
+                            Circle()
+                                .fill(Color.red)
+                                .frame(width: 120, height: 120)
+                                .offset(x: 30)
+                                .blendMode(selectedMode)
+                        }
+                        .frame(height: 150)
+                        .drawingGroup()
+                    }
+                }
+
+                Divider()
+
+                // Blend mode examples
+                Section {
+                    Text("Blend Mode Examples")
+                        .font(.headline)
+
+                    blendModeRow(mode: .normal, label: ".normal")
+                    blendModeRow(mode: .multiply, label: ".multiply")
+                    blendModeRow(mode: .screen, label: ".screen")
+                    blendModeRow(mode: .overlay, label: ".overlay")
+                    blendModeRow(mode: .darken, label: ".darken")
+                    blendModeRow(mode: .lighten, label: ".lighten")
+                    blendModeRow(mode: .difference, label: ".difference")
+                    blendModeRow(mode: .exclusion, label: ".exclusion")
+                }
+
+                Divider()
+
+                // luminanceToAlpha demo
+                Section {
+                    Text("luminanceToAlpha()")
+                        .font(.headline)
+
+                    HStack(spacing: 20) {
+                        VStack {
+                            Text("Original")
+                                .font(.caption)
+                            LinearGradient(
+                                colors: [.black, .white],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                            .frame(width: 100, height: 100)
+                        }
+
+                        VStack {
+                            Text("luminanceToAlpha")
+                                .font(.caption)
+                            LinearGradient(
+                                colors: [.black, .white],
+                                startPoint: .leading,
+                                endPoint: .trailing
+                            )
+                            .frame(width: 100, height: 100)
+                            .luminanceToAlpha()
+                            .background(Color.red)
+                        }
+                    }
+                }
+
+                Divider()
+
+                // drawingGroup demo
+                Section {
+                    Text("drawingGroup()")
+                        .font(.headline)
+
+                    Text("Forces offscreen rendering (flattens view hierarchy)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    ZStack {
+                        ForEach(0..<5) { i in
+                            Circle()
+                                .fill(Color.blue.opacity(0.3))
+                                .frame(width: 80, height: 80)
+                                .offset(x: CGFloat(i * 15), y: CGFloat(i * 15))
+                        }
+                    }
+                    .drawingGroup()
+                    .frame(height: 150)
+                }
+
+                Divider()
+
+                // allowsHitTesting demo
+                Section {
+                    Text("allowsHitTesting()")
+                        .font(.headline)
+
+                    AllowsHitTestingDemo()
+                }
+            }
+            .padding()
+        }
+        .toolbar {
+            PlaygroundSourceLink(file: "BlendModePlayground.swift")
+        }
+    }
+
+    @ViewBuilder
+    private func blendModeRow(mode: BlendMode, label: String) -> some View {
+        HStack {
+            Text(label)
+                .font(.caption)
+                .frame(width: 100, alignment: .leading)
+
+            Spacer()
+
+            ZStack {
+                Circle()
+                    .fill(Color.blue)
+                    .frame(width: 60, height: 60)
+                    .offset(x: -15)
+
+                Circle()
+                    .fill(Color.red)
+                    .frame(width: 60, height: 60)
+                    .offset(x: 15)
+                    .blendMode(mode)
+            }
+            .frame(width: 100, height: 70)
+            .drawingGroup()
+        }
+    }
+}
+
+struct AllowsHitTestingDemo: View {
+    @State internal var tapCount = 0
+    @State internal var hitTestingEnabled = false
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Toggle("Overlay allows hit testing", isOn: $hitTestingEnabled)
+
+            Text("Tap count: \(tapCount)")
+                .font(.caption)
+
+            ZStack {
+                Button("Tap Me") {
+                    tapCount += 1
+                }
+                .buttonStyle(.borderedProminent)
+
+                Color.red.opacity(0.3)
+                    .frame(width: 200, height: 100)
+                    .allowsHitTesting(hitTestingEnabled)
+            }
+
+            Text(hitTestingEnabled ? "Red overlay blocks taps" : "Taps pass through overlay")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/Sources/ShowcaseFuse/ListPlayground.swift
+++ b/Sources/ShowcaseFuse/ListPlayground.swift
@@ -21,6 +21,7 @@ enum ListPlaygroundType: String, CaseIterable {
     case plainStyleSectionedEditActions
     case onMoveDelete
     case positioned
+    case badges
 
     var title: String {
         switch self {
@@ -62,6 +63,8 @@ enum ListPlaygroundType: String, CaseIterable {
             return ".onMove, .onDelete"
         case .positioned:
             return "Positioned"
+        case .badges:
+            return "Badges"
         }
     }
 }
@@ -136,6 +139,9 @@ struct ListPlayground: View {
                     .navigationTitle($0.title)
             case .positioned:
                 PositionedListPlayground()
+                    .navigationTitle($0.title)
+            case .badges:
+                BadgeListPlayground()
                     .navigationTitle($0.title)
             }
         }
@@ -695,6 +701,55 @@ struct PositionedListPlayground: View {
             .listStyle(.plain)
             Text("Content below")
                 .font(.largeTitle)
+        }
+    }
+}
+
+struct BadgeListPlayground: View {
+    var body: some View {
+        List {
+            Section("Badge with Count") {
+                Text("Messages")
+                    .badge(5)
+                Text("Notifications")
+                    .badge(42)
+                Text("No badge (count 0)")
+                    .badge(0)
+            }
+
+            Section("Badge with Text") {
+                Text("Updates")
+                    .badge("New")
+                Text("Status")
+                    .badge("Active")
+            }
+
+            Section("Badge Prominence") {
+                Text("Standard (default)")
+                    .badge(10)
+                Text("Increased prominence")
+                    .badge(10)
+                    .badgeProminence(.increased)
+                Text("Decreased prominence")
+                    .badge(10)
+                    .badgeProminence(.decreased)
+            }
+
+            Section("Navigation with Badges") {
+                NavigationLink {
+                    Text("Detail View")
+                } label: {
+                    Text("Inbox")
+                }
+                .badge(3)
+
+                NavigationLink {
+                    Text("Detail View")
+                } label: {
+                    Text("Spam")
+                }
+                .badge("99+")
+            }
         }
     }
 }

--- a/Sources/ShowcaseFuse/PlaygroundListView.swift
+++ b/Sources/ShowcaseFuse/PlaygroundListView.swift
@@ -8,6 +8,7 @@ enum PlaygroundType: CaseIterable, View {
     case animation
 //    case audio
     case background
+    case blendMode
     case blur
     case border
     case button
@@ -98,6 +99,8 @@ enum PlaygroundType: CaseIterable, View {
 //            return LocalizedStringResource("Audio")
         case .background:
             return LocalizedStringResource("Background", comment: "Title of Background playground")
+        case .blendMode:
+            return LocalizedStringResource("BlendMode", comment: "Title of BlendMode playground")
         case .blur:
             return LocalizedStringResource("Blur", comment: "Title of Blur playground")
         case .border:
@@ -267,6 +270,8 @@ enum PlaygroundType: CaseIterable, View {
 //            AudioPlayground()
         case .background:
             BackgroundPlayground()
+        case .blendMode:
+            BlendModePlayground()
         case .blur:
             BlurPlayground()
         case .border:

--- a/Sources/ShowcaseFuse/PlaygroundListView.swift
+++ b/Sources/ShowcaseFuse/PlaygroundListView.swift
@@ -135,8 +135,6 @@ enum PlaygroundType: CaseIterable, View {
             return LocalizedStringResource("GeometryReader", comment: "Title of GeometryReader playground")
         case .gesture:
             return LocalizedStringResource("Gesture", comment: "Title of Gesture playground")
-        case .viewThatFits:
-            return LocalizedStringResource("ViewThatFits", comment: "Title of ViewThatFits playground")
         case .gradient:
             return LocalizedStringResource("Gradient", comment: "Title of Gradient playground")
         case .graphics:
@@ -250,7 +248,9 @@ enum PlaygroundType: CaseIterable, View {
         case .transition:
             return LocalizedStringResource("Transition", comment: "Title of Transition playground")
         case .videoPlayer:
-            return LocalizedStringResource("Video Player", comment: "Title of WebView playground")
+            return LocalizedStringResource("Video Player", comment: "Title of VideoPlayer playground")
+        case .viewThatFits:
+            return LocalizedStringResource("ViewThatFits", comment: "Title of ViewThatFits playground")
         case .webView:
             return LocalizedStringResource("WebView", comment: "Title of WebView playground")
         case .zIndex:
@@ -306,8 +306,6 @@ enum PlaygroundType: CaseIterable, View {
             GeometryReaderPlayground()
         case .gesture:
             GesturePlayground()
-        case .viewThatFits:
-            ViewThatFitsPlayground()
         case .gradient:
             GradientPlayground()
         case .graphics:
@@ -426,6 +424,8 @@ enum PlaygroundType: CaseIterable, View {
             TransitionPlayground()
         case .videoPlayer:
             VideoPlayerPlayground()
+        case .viewThatFits:
+            ViewThatFitsPlayground()
         case .webView:
             WebViewPlayground()
         case .zIndex:

--- a/Sources/ShowcaseFuse/Resources/Localizable.xcstrings
+++ b/Sources/ShowcaseFuse/Resources/Localizable.xcstrings
@@ -848,6 +848,12 @@
         }
       }
     },
+    "Arrow points right in LTR" : {
+
+    },
+    "Arrow should flip in RTL" : {
+
+    },
     "Asset JPEG Image" : {
 
     },
@@ -1057,6 +1063,9 @@
     },
     "Compose" : {
       "comment" : "Title of Compose playground"
+    },
+    "compositingGroup()" : {
+
     },
     "ConfirmationDialog" : {
       "comment" : "Title of ConfirmationDialog playground"
@@ -1368,6 +1377,12 @@
 
     },
     "Fixed width" : {
+
+    },
+    "Flips for RTL" : {
+
+    },
+    "flipsForRightToLeftLayoutDirection()" : {
 
     },
     "FocusState" : {
@@ -1719,6 +1734,9 @@
 
     },
     "iOS: Not supported (ignored)" : {
+
+    },
+    "Isolates blend modes to the group" : {
 
     },
     "isOn" : {
@@ -2532,6 +2550,9 @@
 
     },
     "Row: 2.%lld" : {
+
+    },
+    "RTL Layout" : {
 
     },
     "Safe Area Insets" : {
@@ -3408,7 +3429,7 @@
       "comment" : "Title of Video sub-playground"
     },
     "Video Player" : {
-      "comment" : "Title of WebView playground"
+      "comment" : "Title of VideoPlayer playground"
     },
     "View 0" : {
 
@@ -3824,6 +3845,9 @@
     "width: 100, height: 100" : {
 
     },
+    "With compositingGroup" : {
+
+    },
     "With minimumScaleFactor(0.5):" : {
 
     },
@@ -3846,6 +3870,9 @@
 
     },
     "withAnimation(repeatCount(3))" : {
+
+    },
+    "Without" : {
 
     },
     "Without scaling (wraps):" : {

--- a/Sources/ShowcaseFuse/Resources/Localizable.xcstrings
+++ b/Sources/ShowcaseFuse/Resources/Localizable.xcstrings
@@ -440,6 +440,9 @@
     "%lld%%" : {
 
     },
+    "→" : {
+
+    },
     "+" : {
 
     },
@@ -848,10 +851,7 @@
         }
       }
     },
-    "Arrow points right in LTR" : {
-
-    },
-    "Arrow should flip in RTL" : {
+    "Applies opacity to group as a whole" : {
 
     },
     "Asset JPEG Image" : {
@@ -949,6 +949,9 @@
     },
     "Border" : {
       "comment" : "Title of Border playground"
+    },
+    "Both arrows point right →" : {
+
     },
     "Bottom" : {
 
@@ -1736,9 +1739,6 @@
     "iOS: Not supported (ignored)" : {
 
     },
-    "Isolates blend modes to the group" : {
-
-    },
     "isOn" : {
 
     },
@@ -2502,6 +2502,9 @@
 
     },
     "RGB" : {
+
+    },
+    "Right arrow should flip to ←" : {
 
     },
     "Rotate" : {
@@ -3879,6 +3882,9 @@
 
     },
     "Without zIndex" : {
+
+    },
+    "Without: overlap area is darker (opacity stacks)\nWith: overlap area same as rest (rendered as one)" : {
 
     },
     "Wrap: This is some long text that should wrap when it exceeds the width of its frame" : {

--- a/Sources/ShowcaseFuse/Resources/Localizable.xcstrings
+++ b/Sources/ShowcaseFuse/Resources/Localizable.xcstrings
@@ -687,6 +687,9 @@
     "alignment: .topLeading" : {
 
     },
+    "allowsHitTesting()" : {
+
+    },
     "Also see the `Transition` playground for view enter/exit animations" : {
 
     },
@@ -911,6 +914,15 @@
     "Black" : {
 
     },
+    "Blend Mode" : {
+
+    },
+    "Blend Mode Examples" : {
+
+    },
+    "BlendMode" : {
+      "comment" : "Title of BlendMode playground"
+    },
     "Blue" : {
 
     },
@@ -1019,6 +1031,12 @@
     "Color + Offset" : {
 
     },
+    "Color Burn" : {
+
+    },
+    "Color Dodge" : {
+
+    },
     "ColorScheme" : {
       "comment" : "Title of ColorScheme playground"
     },
@@ -1109,6 +1127,9 @@
     "Dark" : {
 
     },
+    "Darken" : {
+
+    },
     "Data" : {
 
     },
@@ -1143,6 +1164,9 @@
 
     },
     "Destructive" : {
+
+    },
+    "Difference" : {
 
     },
     "Dimiss" : {
@@ -1256,6 +1280,9 @@
     "Drag, Magnify" : {
 
     },
+    "drawingGroup()" : {
+
+    },
     "EllipitcalGradient" : {
 
     },
@@ -1290,6 +1317,9 @@
 
     },
     "Even" : {
+
+    },
+    "Exclusion" : {
 
     },
     "Expanding container in scroll view" : {
@@ -1419,6 +1449,9 @@
 
     },
     "For animations using After Effects boolean shape operations" : {
+
+    },
+    "Forces offscreen rendering (flattens view hierarchy)" : {
 
     },
     "ForEach index row: %lld" : {
@@ -1832,6 +1865,9 @@
     "Light" : {
 
     },
+    "Lighten" : {
+
+    },
     "Line Spacing" : {
       "comment" : "Title of Line Spacing playground"
     },
@@ -1882,6 +1918,12 @@
     },
     "Lottie Animation" : {
       "comment" : "Title of Lottie playground"
+    },
+    "luminanceToAlpha" : {
+
+    },
+    "luminanceToAlpha()" : {
+
     },
     "Magnify" : {
 
@@ -1960,6 +2002,9 @@
 
     },
     "multilineTextAlignment: This is some long text that should wrap when it exceeds the width of its frame" : {
+
+    },
+    "Multiply" : {
 
     },
     "My custom control" : {
@@ -2053,6 +2098,9 @@
     "No URL\n.frame(100, 100)" : {
 
     },
+    "Normal" : {
+
+    },
     "Not supported on macOS" : {
 
     },
@@ -2126,6 +2174,9 @@
     "Orange" : {
 
     },
+    "Original" : {
+
+    },
     "Output" : {
 
     },
@@ -2137,6 +2188,9 @@
     },
     "Overlay" : {
       "comment" : "Title of Overlay playground"
+    },
+    "Overlay allows hit testing" : {
+
     },
     "Overridden to title font" : {
 
@@ -2399,6 +2453,9 @@
     "Red" : {
 
     },
+    "Red overlay blocks taps" : {
+
+    },
     "Red, .opacity(0.5)" : {
 
     },
@@ -2507,6 +2564,9 @@
     "ScenePhase history" : {
 
     },
+    "Screen" : {
+
+    },
     "Scroll to 0" : {
 
     },
@@ -2580,6 +2640,9 @@
 
     },
     "Seek to specific position (0.0 - 1.0)" : {
+
+    },
+    "Select Blend Mode" : {
 
     },
     "Select Media" : {
@@ -3054,6 +3117,9 @@
     "Tap Count: %lld" : {
 
     },
+    "Tap Me" : {
+
+    },
     "Tap to dismiss" : {
 
     },
@@ -3099,6 +3165,9 @@
           }
         }
       }
+    },
+    "Taps pass through overlay" : {
+
     },
     "Teal" : {
 

--- a/Sources/ShowcaseFuse/Resources/Localizable.xcstrings
+++ b/Sources/ShowcaseFuse/Resources/Localizable.xcstrings
@@ -317,6 +317,9 @@
     ".red.opacity(0.5)" : {
 
     },
+    ".regularMaterial" : {
+
+    },
     ".repeatForever()" : {
 
     },
@@ -368,10 +371,31 @@
     ".submitLabel(.%@)" : {
 
     },
+    ".symbolVariant(.circle.fill)" : {
+
+    },
+    ".symbolVariant(.circle)" : {
+
+    },
+    ".symbolVariant(.fill)" : {
+
+    },
+    ".symbolVariant(.slash)" : {
+
+    },
+    ".symbolVariant(.square)" : {
+
+    },
     ".textInputAutocapitalization" : {
 
     },
     ".textInputAutocapitalization(.%@)" : {
+
+    },
+    ".thickMaterial" : {
+
+    },
+    ".thinMaterial" : {
 
     },
     ".tint(.red)" : {
@@ -408,6 +432,12 @@
 
     },
     ".transition(.slide)" : {
+
+    },
+    ".ultraThickMaterial" : {
+
+    },
+    ".ultraThinMaterial" : {
 
     },
     "\"CustomRed\"" : {
@@ -486,6 +516,9 @@
 
     },
     "9. Current Frame" : {
+
+    },
+    "99+" : {
 
     },
     "123" : {
@@ -650,6 +683,9 @@
     },
     "Accessibility" : {
       "comment" : "Title of Accessibility playground"
+    },
+    "Active" : {
+
     },
     "Add" : {
 
@@ -851,9 +887,6 @@
         }
       }
     },
-    "Applies opacity to group as a whole" : {
-
-    },
     "Asset JPEG Image" : {
 
     },
@@ -882,6 +915,15 @@
       "comment" : "Title of Background playground"
     },
     "background()" : {
+
+    },
+    "Badge Prominence" : {
+
+    },
+    "Badge with Count" : {
+
+    },
+    "Badge with Text" : {
 
     },
     "BB" : {
@@ -949,9 +991,6 @@
     },
     "Border" : {
       "comment" : "Title of Border playground"
-    },
-    "Both arrows point right →" : {
-
     },
     "Bottom" : {
 
@@ -1049,6 +1088,9 @@
     "ColorScheme" : {
       "comment" : "Title of ColorScheme playground"
     },
+    "Combined: .circle.fill" : {
+
+    },
     "Combined: opacity+slide" : {
 
     },
@@ -1066,9 +1108,6 @@
     },
     "Compose" : {
       "comment" : "Title of Compose playground"
-    },
-    "compositingGroup()" : {
-
     },
     "ConfirmationDialog" : {
       "comment" : "Title of ConfirmationDialog playground"
@@ -1163,6 +1202,9 @@
     "DatePicker .disabled" : {
 
     },
+    "Decreased prominence" : {
+
+    },
     "Default" : {
 
     },
@@ -1176,6 +1218,9 @@
 
     },
     "Destructive" : {
+
+    },
+    "Detail View" : {
 
     },
     "Difference" : {
@@ -1688,7 +1733,13 @@
     "in: Capsule()" : {
 
     },
+    "Inbox" : {
+
+    },
     "Inc" : {
+
+    },
+    "Increased prominence" : {
 
     },
     "Increment" : {
@@ -1877,6 +1928,9 @@
     "LazyVStack.%@" : {
 
     },
+    "Leading" : {
+
+    },
     "Leading: %lld" : {
 
     },
@@ -1989,11 +2043,20 @@
     "Mask" : {
       "comment" : "Title of Mask playground"
     },
+    "Material Backgrounds" : {
+
+    },
+    "Material in shape" : {
+
+    },
     "maxWidth: .infinity, maxHeight: .infinity" : {
 
     },
     "Menu" : {
       "comment" : "Title of Menu playground"
+    },
+    "Messages" : {
+
     },
     "MinimumScaleFactor" : {
       "comment" : "Title of MinimumScaleFactor playground"
@@ -2052,6 +2115,9 @@
     "Navigate forward to %lld" : {
 
     },
+    "Navigation with Badges" : {
+
+    },
     "NavigationLink" : {
 
     },
@@ -2089,6 +2155,9 @@
     "Nested views" : {
 
     },
+    "New" : {
+
+    },
     "New Item" : {
 
     },
@@ -2105,6 +2174,9 @@
 
     },
     "NO" : {
+
+    },
+    "No badge (count 0)" : {
 
     },
     "No scale" : {
@@ -2502,9 +2574,6 @@
 
     },
     "RGB" : {
-
-    },
-    "Right arrow should flip to ←" : {
 
     },
     "Rotate" : {
@@ -2950,6 +3019,9 @@
     "Sign In" : {
 
     },
+    "Simplified on Android: semi-transparent white overlay" : {
+
+    },
     "Simulate a custom control with an accessibility label, value, and traits:" : {
 
     },
@@ -3000,6 +3072,9 @@
     "Spacer:" : {
 
     },
+    "Spam" : {
+
+    },
     "SQL" : {
       "comment" : "Title of SQL playground"
     },
@@ -3021,6 +3096,9 @@
     "Standard" : {
 
     },
+    "Standard (default)" : {
+
+    },
     "Standard Row Background" : {
 
     },
@@ -3031,6 +3109,9 @@
       "comment" : "Title of State playground"
     },
     "State tap count: %lld" : {
+
+    },
+    "Status" : {
 
     },
     "Storage" : {
@@ -3106,6 +3187,9 @@
 
     },
     "Symbol Image Weights" : {
+
+    },
+    "Symbol Variants" : {
 
     },
     "System" : {
@@ -3373,6 +3457,9 @@
     "Tracking: 10" : {
 
     },
+    "Trailing" : {
+
+    },
     "Trailing: %lld" : {
 
     },
@@ -3392,6 +3479,9 @@
 
     },
     "UnevenRoundedRectangle" : {
+
+    },
+    "Updates" : {
 
     },
     "URLs:" : {
@@ -3848,9 +3938,6 @@
     "width: 100, height: 100" : {
 
     },
-    "With compositingGroup" : {
-
-    },
     "With minimumScaleFactor(0.5):" : {
 
     },
@@ -3875,16 +3962,10 @@
     "withAnimation(repeatCount(3))" : {
 
     },
-    "Without" : {
-
-    },
     "Without scaling (wraps):" : {
 
     },
     "Without zIndex" : {
-
-    },
-    "Without: overlap area is darker (opacity stacks)\nWith: overlap area same as rest (rendered as one)" : {
 
     },
     "Wrap: This is some long text that should wrap when it exceeds the width of its frame" : {

--- a/Sources/ShowcaseFuse/SymbolPlayground.swift
+++ b/Sources/ShowcaseFuse/SymbolPlayground.swift
@@ -89,6 +89,51 @@ struct SymbolPlayground: View {
                     Image(systemName: "star.fill")
                         .font(.title)
                 }
+
+                // Symbol Variants
+                Divider()
+                Text("Symbol Variants").font(.headline)
+
+                HStack {
+                    Text(".symbolVariant(.fill)")
+                    Spacer()
+                    Image(systemName: "heart")
+                        .symbolVariant(.fill)
+                }
+                HStack {
+                    Text(".symbolVariant(.circle)")
+                    Spacer()
+                    Image(systemName: "plus")
+                        .symbolVariant(.circle)
+                }
+                HStack {
+                    Text(".symbolVariant(.circle.fill)")
+                    Spacer()
+                    Image(systemName: "plus")
+                        .symbolVariant(.circle.fill)
+                }
+                HStack {
+                    Text(".symbolVariant(.square)")
+                    Spacer()
+                    Image(systemName: "arrow.forward")
+                        .symbolVariant(.square)
+                }
+                HStack {
+                    Text(".symbolVariant(.slash)")
+                    Spacer()
+                    Image(systemName: "bell")
+                        .symbolVariant(.slash)
+                }
+                HStack {
+                    Text("Combined: .circle.fill")
+                    Spacer()
+                    VStack {
+                        Image(systemName: "plus")
+                        Image(systemName: "minus")
+                        Image(systemName: "xmark")
+                    }
+                    .symbolVariant(.circle.fill)
+                }
             }
             .padding()
         }


### PR DESCRIPTION
ignoreHitTesting can eventually be moved into GesturePlayground

Complement to https://github.com/skiptools/skip-ui/pull/303 and https://github.com/skiptools/skip-fuse-ui/pull/82

- [X] REQUIRED: I have signed the [Contributor Agreement](https://github.com/skiptools/clabot-config)
- [X] REQUIRED: I have tested my change locally with `swift test`
- [X] OPTIONAL: I have tested my change on an iOS simulator or device
- [X] OPTIONAL: I have tested my change on an Android emulator or device

